### PR TITLE
fix: add redirect from /docs to /docs/introduction/

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,9 @@ import mermaid from 'astro-mermaid';
 
 // https://astro.build/config
 export default defineConfig({
+  redirects: {
+    '/docs': '/docs/introduction/',
+  },
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
## Summary

Fixes the 404 error when users visit  by adding a proper redirect to the introduction page.

## Problem

- Visiting  returns 404 Not Found
- Users expect to land on a starting page when clicking "docs"
- Poor user experience for documentation entry point

## Solution

- Added redirect configuration in 
-  now redirects to 
- Uses Astro's built-in redirects for static hosting
- Creates proper meta refresh redirect with SEO-friendly attributes

## Implementation

- **Method**: Astro redirects configuration
- **Generated output**:  with meta refresh
- **SEO**: Includes  and canonical link
- **Fallback**: Manual link for users with disabled meta refresh

## Test Plan

- [x] Dev server redirect working
- [x] Build generates redirect HTML
- [x] Pre-push hooks passing (build, validation, links)
- [x] No broken functionality

## Result

Users visiting  will now be automatically redirected to  where they can start exploring the documentation.