### PR TITLE
feat: add Scalar interactive API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ Content here...
 
 ## Related Repositories
 
-| Repository | Description |
-|------------|-------------|
-| [duragraph](https://github.com/Duragraph/duragraph) | Core API server |
-| [duragraph-python](https://github.com/Duragraph/duragraph-python) | Python SDK |
-| [duragraph-go](https://github.com/Duragraph/duragraph-go) | Go SDK |
+| Repository                                                            | Description      |
+| --------------------------------------------------------------------- | ---------------- |
+| [duragraph](https://github.com/Duragraph/duragraph)                   | Core API server  |
+| [duragraph-python](https://github.com/Duragraph/duragraph-python)     | Python SDK       |
+| [duragraph-go](https://github.com/Duragraph/duragraph-go)             | Go SDK           |
 | [duragraph-examples](https://github.com/Duragraph/duragraph-examples) | Example projects |
-| [duragraph-studio](https://github.com/Duragraph/duragraph-studio) | Interactive UI |
+| [duragraph-studio](https://github.com/Duragraph/duragraph-studio)     | Interactive UI   |
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@astrojs/react": "^4.4.2",
     "@astrojs/starlight": "^0.37.1",
+    "@scalar/astro": "^0.1.6",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
     "astro": "^5.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.37.1
         version: 0.37.1(astro@5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(typescript@5.9.3)(yaml@2.8.2))
+      '@scalar/astro':
+        specifier: ^0.1.6
+        version: 0.1.6(astro@5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(typescript@5.9.3)(yaml@2.8.2))
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.1.18)
@@ -847,6 +850,24 @@ packages:
     resolution: {integrity: sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==}
     cpu: [x64]
     os: [win32]
+
+  '@scalar/astro@0.1.6':
+    resolution: {integrity: sha512-K6PoVuViOT6GZZ1jxeDhscQdoZgYhNH0yYEHs2nWsVbNVIj7qhX456bvihAptQiLiKDdVSHO7hdR1Rxcp+q3Pw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      astro: ^4.0.0 || ^5.0.0
+
+  '@scalar/core@0.3.28':
+    resolution: {integrity: sha512-Ka+g5P3Fe4f9lsJcBxfI+XAgwMYeZRgzIBWw1/HBrDoRmH3rV/N//410MBKEYXUw7pWpS+dZPJANZRvU5jtxhw==}
+    engines: {node: '>=20'}
+
+  '@scalar/helpers@0.2.4':
+    resolution: {integrity: sha512-G7oGybO2QXM+MIxa4OZLXaYsS9mxKygFgOcY4UOXO6xpVoY5+8rahdak9cPk7HNj8RZSt4m/BveoT8g5BtnXxg==}
+    engines: {node: '>=20'}
+
+  '@scalar/types@0.5.4':
+    resolution: {integrity: sha512-5FNQH/zx3tnERzxfpErscPHfRxLCuhncmhFYiaSz196Xi2iG1YI08BtxTV2slfT6of52epJ/MrKerarplKf9eg==}
+    engines: {node: '>=20'}
 
   '@shikijs/core@3.20.0':
     resolution: {integrity: sha512-f2ED7HYV4JEk827mtMDwe/yQ25pRiXZmtHjWF8uzZKuKiEsJR7Ce1nuQ+HhV9FzDcbIo4ObBCD9GPTzNuy9S1g==}
@@ -2419,6 +2440,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
@@ -2800,6 +2826,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
@@ -2851,6 +2881,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-fest@5.0.0:
+    resolution: {integrity: sha512-GeJop7+u7BYlQ6yQCAY1nBQiRSHR+6OdCEtd8Bwp9a3NK3+fWAVjOaPKJDteB9f6cIJ0wt4IfnScjLG450EpXA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3134,6 +3168,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.5:
+    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3936,6 +3973,24 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.54.0':
     optional: true
+
+  '@scalar/astro@0.1.6(astro@5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(typescript@5.9.3)(yaml@2.8.2))':
+    dependencies:
+      '@scalar/core': 0.3.28
+      astro: 5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(typescript@5.9.3)(yaml@2.8.2)
+
+  '@scalar/core@0.3.28':
+    dependencies:
+      '@scalar/types': 0.5.4
+
+  '@scalar/helpers@0.2.4': {}
+
+  '@scalar/types@0.5.4':
+    dependencies:
+      '@scalar/helpers': 0.2.4
+      nanoid: 5.1.5
+      type-fest: 5.0.0
+      zod: 4.3.5
 
   '@shikijs/core@3.20.0':
     dependencies:
@@ -6008,6 +6063,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.5: {}
+
   neotraverse@0.6.18: {}
 
   nlcst-to-string@4.0.0:
@@ -6526,6 +6583,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.4.3
 
+  tagged-tag@1.0.0: {}
+
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
@@ -6556,6 +6615,10 @@ snapshots:
   tslib@2.8.1: {}
 
   type-fest@4.41.0: {}
+
+  type-fest@5.0.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -6772,5 +6835,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.5: {}
 
   zwitch@2.0.4: {}

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,1644 @@
+openapi: 3.1.0
+info:
+  title: DuraGraph API
+  version: 1.0.0
+  description: |
+    DuraGraph is a LangGraph Cloud-compatible API for AI workflow orchestration.
+    This specification documents all Phase 1 endpoints for assistant, thread, and run management.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  contact:
+    name: DuraGraph
+    url: https://duragraph.ai
+
+servers:
+  - url: http://localhost:8081
+    description: Local development server
+  - url: https://api.duragraph.ai
+    description: Production server
+
+tags:
+  - name: System
+    description: Health and system information endpoints
+  - name: Assistants
+    description: Assistant management endpoints
+  - name: Threads
+    description: Thread management endpoints
+  - name: Runs
+    description: Run execution endpoints
+  - name: State
+    description: Thread state and checkpoint management
+  - name: Streaming
+    description: Server-Sent Events streaming endpoints
+
+paths:
+  # System Endpoints
+  /health:
+    get:
+      tags: [System]
+      summary: Health check
+      operationId: healthCheck
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: healthy
+
+  /ok:
+    get:
+      tags: [System]
+      summary: Simple health check
+      operationId: ok
+      responses:
+        '200':
+          description: Service is running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+
+  /info:
+    get:
+      tags: [System]
+      summary: Server information
+      operationId: info
+      responses:
+        '200':
+          description: Server version and capabilities
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerInfo'
+
+  /metrics:
+    get:
+      tags: [System]
+      summary: Prometheus metrics
+      operationId: metrics
+      responses:
+        '200':
+          description: Prometheus metrics in text format
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  # Assistant Endpoints
+  /api/v1/assistants:
+    post:
+      tags: [Assistants]
+      summary: Create assistant
+      operationId: createAssistant
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAssistantRequest'
+            example:
+              name: my-assistant
+              model: gpt-4
+              instructions: You are a helpful assistant.
+      responses:
+        '201':
+          description: Assistant created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+    get:
+      tags: [Assistants]
+      summary: List assistants
+      operationId: listAssistants
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: List of assistants
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAssistantsResponse'
+
+  /api/v1/assistants/search:
+    post:
+      tags: [Assistants]
+      summary: Search assistants
+      operationId: searchAssistants
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchAssistantsRequest'
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListAssistantsResponse'
+
+  /api/v1/assistants/count:
+    post:
+      tags: [Assistants]
+      summary: Count assistants
+      operationId: countAssistants
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CountAssistantsRequest'
+      responses:
+        '200':
+          description: Count result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CountResponse'
+
+  /api/v1/assistants/{assistant_id}:
+    get:
+      tags: [Assistants]
+      summary: Get assistant
+      operationId: getAssistant
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/AssistantId'
+      responses:
+        '200':
+          description: Assistant found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      tags: [Assistants]
+      summary: Update assistant
+      operationId: updateAssistant
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/AssistantId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAssistantRequest'
+      responses:
+        '200':
+          description: Assistant updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags: [Assistants]
+      summary: Delete assistant
+      operationId: deleteAssistant
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/AssistantId'
+      responses:
+        '204':
+          description: Assistant deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/assistants/{assistant_id}/versions:
+    get:
+      tags: [Assistants]
+      summary: List assistant versions
+      operationId: listAssistantVersions
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/AssistantId'
+      responses:
+        '200':
+          description: List of versions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssistantVersionResponse'
+
+    post:
+      tags: [Assistants]
+      summary: Create assistant version
+      operationId: createAssistantVersion
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/AssistantId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateAssistantVersionRequest'
+      responses:
+        '201':
+          description: Version created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantVersionResponse'
+
+  /api/v1/assistants/{assistant_id}/latest:
+    post:
+      tags: [Assistants]
+      summary: Set latest version
+      operationId: setLatestVersion
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/AssistantId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetLatestVersionRequest'
+      responses:
+        '200':
+          description: Latest version set
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantResponse'
+
+  /api/v1/assistants/{assistant_id}/schemas:
+    get:
+      tags: [Assistants]
+      summary: Get assistant schemas
+      operationId: getAssistantSchemas
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/AssistantId'
+      responses:
+        '200':
+          description: Assistant schemas
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssistantSchemaResponse'
+
+  # Thread Endpoints
+  /api/v1/threads:
+    post:
+      tags: [Threads]
+      summary: Create thread
+      operationId: createThread
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateThreadRequest'
+      responses:
+        '201':
+          description: Thread created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateThreadResponse'
+
+    get:
+      tags: [Threads]
+      summary: List threads
+      operationId: listThreads
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: List of threads
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListThreadsResponse'
+
+  /api/v1/threads/search:
+    post:
+      tags: [Threads]
+      summary: Search threads
+      operationId: searchThreads
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SearchThreadsRequest'
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListThreadsResponse'
+
+  /api/v1/threads/count:
+    post:
+      tags: [Threads]
+      summary: Count threads
+      operationId: countThreads
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CountThreadsRequest'
+      responses:
+        '200':
+          description: Count result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CountResponse'
+
+  /api/v1/threads/{thread_id}:
+    get:
+      tags: [Threads]
+      summary: Get thread
+      operationId: getThread
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      responses:
+        '200':
+          description: Thread found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    patch:
+      tags: [Threads]
+      summary: Update thread
+      operationId: updateThread
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateThreadRequest'
+      responses:
+        '200':
+          description: Thread updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadResponse'
+
+    delete:
+      tags: [Threads]
+      summary: Delete thread
+      operationId: deleteThread
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      responses:
+        '204':
+          description: Thread deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/threads/{thread_id}/messages:
+    post:
+      tags: [Threads]
+      summary: Add message to thread
+      operationId: addMessage
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddMessageRequest'
+      responses:
+        '201':
+          description: Message added
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+
+  /api/v1/threads/{thread_id}/copy:
+    post:
+      tags: [Threads]
+      summary: Copy (fork) thread
+      operationId: copyThread
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CopyThreadRequest'
+      responses:
+        '201':
+          description: Thread copied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CopyThreadResponse'
+
+  # Thread State Endpoints
+  /api/v1/threads/{thread_id}/state:
+    get:
+      tags: [State]
+      summary: Get thread state
+      operationId: getThreadState
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      responses:
+        '200':
+          description: Thread state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadStateResponse'
+
+    post:
+      tags: [State]
+      summary: Update thread state
+      operationId: updateThreadState
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateThreadStateRequest'
+      responses:
+        '200':
+          description: State updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadStateResponse'
+
+  /api/v1/threads/{thread_id}/state/{checkpoint_id}:
+    get:
+      tags: [State]
+      summary: Get state at checkpoint
+      operationId: getStateAtCheckpoint
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - name: checkpoint_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: State at checkpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadStateResponse'
+
+  /api/v1/threads/{thread_id}/state/checkpoint:
+    post:
+      tags: [State]
+      summary: Create checkpoint
+      operationId: createCheckpoint
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      responses:
+        '201':
+          description: Checkpoint created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  checkpoint_id:
+                    type: string
+
+  /api/v1/threads/{thread_id}/history:
+    get:
+      tags: [State]
+      summary: Get thread history
+      operationId: getThreadHistory
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+        - name: before
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Thread history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ThreadHistoryEntry'
+
+    post:
+      tags: [State]
+      summary: Query thread history
+      operationId: queryThreadHistory
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetThreadHistoryRequest'
+      responses:
+        '200':
+          description: Thread history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ThreadHistoryEntry'
+
+  # Run Endpoints
+  /api/v1/threads/{thread_id}/runs:
+    post:
+      tags: [Runs]
+      summary: Create run
+      operationId: createRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRunRequest'
+            example:
+              assistant_id: asst_123
+              input:
+                message: Hello, world!
+      responses:
+        '201':
+          description: Run created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateRunResponse'
+
+    get:
+      tags: [Runs]
+      summary: List runs for thread
+      operationId: listRuns
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: List of runs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GetRunResponse'
+
+  /api/v1/threads/{thread_id}/runs/stream:
+    post:
+      tags: [Streaming]
+      summary: Create run with streaming
+      operationId: createRunWithStream
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRunRequest'
+      responses:
+        '200':
+          description: Server-Sent Events stream
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/StreamEvent'
+
+  /api/v1/threads/{thread_id}/runs/{run_id}:
+    get:
+      tags: [Runs]
+      summary: Get run
+      operationId: getRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - $ref: '#/components/parameters/RunId'
+      responses:
+        '200':
+          description: Run found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRunResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags: [Runs]
+      summary: Delete run
+      operationId: deleteRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - $ref: '#/components/parameters/RunId'
+      responses:
+        '200':
+          description: Run deleted
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Run is still in progress
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/threads/{thread_id}/runs/{run_id}/cancel:
+    post:
+      tags: [Runs]
+      summary: Cancel run
+      operationId: cancelRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - $ref: '#/components/parameters/RunId'
+      responses:
+        '200':
+          description: Run cancelled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  run_id:
+                    type: string
+                  status:
+                    type: string
+                    example: cancelled
+
+  /api/v1/threads/{thread_id}/runs/{run_id}/resume:
+    post:
+      tags: [Runs]
+      summary: Resume interrupted run
+      description: |
+        Resume a run that is in requires_action state. Supports LangGraph Command pattern
+        for human-in-the-loop workflows including state updates, resume values, and goto.
+      operationId: resumeRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - $ref: '#/components/parameters/RunId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResumeRunRequest'
+      responses:
+        '200':
+          description: Run resumed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  run_id:
+                    type: string
+                  status:
+                    type: string
+                    example: resumed
+        '400':
+          description: Run is not in requires_action state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/v1/threads/{thread_id}/runs/{run_id}/join:
+    get:
+      tags: [Runs]
+      summary: Wait for run completion
+      operationId: joinRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - $ref: '#/components/parameters/RunId'
+        - name: timeout
+          in: query
+          schema:
+            type: string
+            default: 5m
+          description: Timeout duration (e.g., 5m, 30s)
+      responses:
+        '200':
+          description: Run completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRunResponse'
+
+  /api/v1/threads/{thread_id}/runs/{run_id}/stream:
+    get:
+      tags: [Streaming]
+      summary: Stream existing run events
+      operationId: streamRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ThreadId'
+        - $ref: '#/components/parameters/RunId'
+      responses:
+        '200':
+          description: Server-Sent Events stream
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/StreamEvent'
+
+  # Stateless Run Endpoints
+  /api/v1/runs:
+    post:
+      tags: [Runs]
+      summary: Create stateless run
+      operationId: createStatelessRun
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRunRequest'
+      responses:
+        '201':
+          description: Run created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateRunResponse'
+
+  /api/v1/runs/wait:
+    post:
+      tags: [Runs]
+      summary: Create run and wait for completion
+      operationId: createRunAndWait
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: timeout
+          in: query
+          schema:
+            type: string
+            default: 5m
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRunRequest'
+      responses:
+        '200':
+          description: Run completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRunResponse'
+
+  /api/v1/runs/stream:
+    post:
+      tags: [Streaming]
+      summary: Create stateless run with streaming
+      operationId: createStatelessRunWithStream
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRunRequest'
+      responses:
+        '200':
+          description: Server-Sent Events stream
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/StreamEvent'
+
+  /api/v1/runs/batch:
+    post:
+      tags: [Runs]
+      summary: Create batch runs
+      operationId: createBatchRuns
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/CreateRunRequest'
+      responses:
+        '201':
+          description: Runs created
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CreateRunResponse'
+
+  /api/v1/runs/cancel:
+    post:
+      tags: [Runs]
+      summary: Cancel multiple runs
+      operationId: cancelStatelessRuns
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                run_ids:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Cancellation results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    run_id:
+                      type: string
+                    status:
+                      type: string
+
+  # Legacy Streaming
+  /api/v1/stream:
+    get:
+      tags: [Streaming]
+      summary: Stream events (legacy)
+      operationId: streamEvents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: run_id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Server-Sent Events stream
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/StreamEvent'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    AssistantId:
+      name: assistant_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The assistant ID
+
+    ThreadId:
+      name: thread_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The thread ID
+
+    RunId:
+      name: run_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The run ID
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    ServerInfo:
+      type: object
+      properties:
+        version:
+          type: string
+          example: "1.0.0"
+        name:
+          type: string
+          example: DuraGraph
+        features:
+          type: array
+          items:
+            type: string
+          example: ["streaming", "checkpoints", "versioning"]
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          example: invalid_request
+        message:
+          type: string
+          example: The request was invalid
+        code:
+          type: string
+
+    CreateAssistantRequest:
+      type: object
+      required: [name]
+      properties:
+        graph_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        instructions:
+          type: string
+        tools:
+          type: array
+          items:
+            type: object
+        metadata:
+          type: object
+          additionalProperties: true
+        config:
+          type: object
+          additionalProperties: true
+        context:
+          type: array
+          items:
+            type: object
+
+    UpdateAssistantRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        instructions:
+          type: string
+        tools:
+          type: array
+          items:
+            type: object
+
+    AssistantResponse:
+      type: object
+      properties:
+        assistant_id:
+          type: string
+        graph_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        model:
+          type: string
+        instructions:
+          type: string
+        tools:
+          type: array
+          items:
+            type: object
+        metadata:
+          type: object
+        config:
+          type: object
+        context:
+          type: array
+          items:
+            type: object
+        version:
+          type: integer
+        created_at:
+          type: integer
+          format: int64
+        updated_at:
+          type: integer
+          format: int64
+
+    ListAssistantsResponse:
+      type: object
+      properties:
+        assistants:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssistantResponse'
+        total:
+          type: integer
+
+    SearchAssistantsRequest:
+      type: object
+      properties:
+        graph_id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+        limit:
+          type: integer
+          default: 20
+        offset:
+          type: integer
+          default: 0
+
+    CountAssistantsRequest:
+      type: object
+      properties:
+        graph_id:
+          type: string
+        metadata:
+          type: object
+
+    CountResponse:
+      type: object
+      properties:
+        count:
+          type: integer
+
+    AssistantVersionResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        assistant_id:
+          type: string
+        version:
+          type: integer
+        graph_id:
+          type: string
+        config:
+          type: object
+        context:
+          type: array
+          items:
+            type: object
+        created_at:
+          type: integer
+          format: int64
+
+    CreateAssistantVersionRequest:
+      type: object
+      properties:
+        graph_id:
+          type: string
+        config:
+          type: object
+        context:
+          type: array
+          items:
+            type: object
+
+    SetLatestVersionRequest:
+      type: object
+      required: [version]
+      properties:
+        version:
+          type: integer
+
+    AssistantSchemaResponse:
+      type: object
+      properties:
+        graph_id:
+          type: string
+        input_schema:
+          type: object
+        output_schema:
+          type: object
+        state_schema:
+          type: object
+        config_schema:
+          type: object
+
+    CreateThreadRequest:
+      type: object
+      properties:
+        metadata:
+          type: object
+          additionalProperties: true
+
+    CreateThreadResponse:
+      type: object
+      properties:
+        thread_id:
+          type: string
+        metadata:
+          type: object
+        created_at:
+          type: string
+          format: date-time
+
+    UpdateThreadRequest:
+      type: object
+      properties:
+        metadata:
+          type: object
+
+    ThreadResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/MessageResponse'
+        metadata:
+          type: object
+        created_at:
+          type: integer
+          format: int64
+        updated_at:
+          type: integer
+          format: int64
+
+    ListThreadsResponse:
+      type: object
+      properties:
+        threads:
+          type: array
+          items:
+            $ref: '#/components/schemas/ThreadResponse'
+        total:
+          type: integer
+
+    SearchThreadsRequest:
+      type: object
+      properties:
+        status:
+          type: string
+        metadata:
+          type: object
+        limit:
+          type: integer
+          default: 20
+        offset:
+          type: integer
+          default: 0
+
+    CountThreadsRequest:
+      type: object
+      properties:
+        status:
+          type: string
+        metadata:
+          type: object
+
+    AddMessageRequest:
+      type: object
+      required: [role, content]
+      properties:
+        role:
+          type: string
+          enum: [user, assistant, system]
+        content:
+          type: string
+        metadata:
+          type: object
+
+    MessageResponse:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          type: string
+        content:
+          type: string
+        metadata:
+          type: object
+        created_at:
+          type: integer
+          format: int64
+
+    CopyThreadRequest:
+      type: object
+      properties:
+        checkpoint_id:
+          type: string
+
+    CopyThreadResponse:
+      type: object
+      properties:
+        thread_id:
+          type: string
+
+    ThreadStateResponse:
+      type: object
+      properties:
+        values:
+          type: object
+          additionalProperties: true
+        next:
+          type: array
+          items:
+            type: string
+        tasks:
+          type: array
+          items:
+            type: object
+        metadata:
+          type: object
+        created_at:
+          type: integer
+          format: int64
+        checkpoint_id:
+          type: string
+        checkpoint_ns:
+          type: string
+        parent_config:
+          type: object
+
+    UpdateThreadStateRequest:
+      type: object
+      required: [values]
+      properties:
+        values:
+          type: object
+          additionalProperties: true
+        as_node:
+          type: string
+        checkpoint_ns:
+          type: string
+
+    ThreadHistoryEntry:
+      type: object
+      properties:
+        checkpoint_id:
+          type: string
+        parent_checkpoint_id:
+          type: string
+        values:
+          type: object
+        metadata:
+          type: object
+        created_at:
+          type: integer
+          format: int64
+
+    GetThreadHistoryRequest:
+      type: object
+      properties:
+        checkpoint_ns:
+          type: string
+        limit:
+          type: integer
+        before:
+          type: string
+
+    CreateRunRequest:
+      type: object
+      required: [assistant_id]
+      properties:
+        assistant_id:
+          type: string
+        thread_id:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+        metadata:
+          type: object
+        config:
+          type: object
+        kwargs:
+          type: object
+        stream_mode:
+          type: array
+          items:
+            type: string
+            enum: [values, updates, messages, messages-tuple, debug, events, custom]
+        on_completion:
+          type: string
+        interrupt_before:
+          type: array
+          items:
+            type: string
+          description: Node IDs to interrupt before execution
+        interrupt_after:
+          type: array
+          items:
+            type: string
+          description: Node IDs to interrupt after execution
+        webhook:
+          type: string
+          format: uri
+
+    CreateRunResponse:
+      type: object
+      properties:
+        run_id:
+          type: string
+        thread_id:
+          type: string
+        assistant_id:
+          type: string
+        status:
+          type: string
+          enum: [queued, pending, running, success, error, cancelled, interrupted, timeout]
+        metadata:
+          type: object
+        kwargs:
+          type: object
+        created_at:
+          type: string
+          format: date-time
+
+    GetRunResponse:
+      type: object
+      properties:
+        run_id:
+          type: string
+        thread_id:
+          type: string
+        assistant_id:
+          type: string
+        status:
+          type: string
+          enum: [queued, pending, running, success, error, cancelled, interrupted, timeout]
+        input:
+          type: object
+        output:
+          type: object
+        error:
+          type: string
+        metadata:
+          type: object
+        kwargs:
+          type: object
+        created_at:
+          type: string
+          format: date-time
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+
+    SubmitToolOutputsRequest:
+      type: object
+      required: [tool_outputs]
+      properties:
+        tool_outputs:
+          type: array
+          items:
+            $ref: '#/components/schemas/ToolOutput'
+
+    ToolOutput:
+      type: object
+      required: [tool_call_id, output]
+      properties:
+        tool_call_id:
+          type: string
+        output:
+          type: string
+
+    StreamEvent:
+      type: object
+      properties:
+        event:
+          type: string
+          enum: [metadata, values, updates, messages, debug, error, end]
+        data:
+          type: object
+          additionalProperties: true
+
+    ResumeRunRequest:
+      type: object
+      description: Request to resume an interrupted run with LangGraph Command support
+      properties:
+        input:
+          type: object
+          additionalProperties: true
+          description: Input to resume with
+        command:
+          $ref: '#/components/schemas/Command'
+        config:
+          type: object
+          additionalProperties: true
+          description: Config overrides for the resumed run
+
+    Command:
+      type: object
+      description: LangGraph Command object for resuming with specific actions
+      properties:
+        resume:
+          description: Value to resume with (for interrupt_before/after)
+        update:
+          type: object
+          additionalProperties: true
+          description: State values to update before resuming
+        send:
+          type: array
+          items:
+            $ref: '#/components/schemas/SendMessage'
+          description: Messages to send to specific nodes
+        goto:
+          type: string
+          description: Node to jump to (skip current)
+
+    SendMessage:
+      type: object
+      required: [node, message]
+      properties:
+        node:
+          type: string
+          description: Target node ID
+        message:
+          description: Message to send
+
+    InterruptResponse:
+      type: object
+      description: Response when a run is interrupted
+      properties:
+        run_id:
+          type: string
+        thread_id:
+          type: string
+        status:
+          type: string
+        interrupt_type:
+          type: string
+          enum: [before, after]
+        node_id:
+          type: string
+        reason:
+          type: string
+        state:
+          type: object
+          additionalProperties: true
+        tool_calls:
+          type: array
+          items:
+            type: object

--- a/src/content/docs/docs/api-reference/overview.mdx
+++ b/src/content/docs/docs/api-reference/overview.mdx
@@ -5,6 +5,10 @@ description: Complete REST API documentation for DuraGraph
 
 DuraGraph provides a RESTful API for managing assistants, threads, runs, and real-time streaming. The API is designed for LangGraph Cloud compatibility while adding DuraGraph-specific features.
 
+:::tip[Interactive API Reference]
+Try our **[Interactive API Reference](/api/reference)** powered by Scalar - explore endpoints, view schemas, and test API calls directly in your browser.
+:::
+
 ## Base URL
 
 ```

--- a/src/content/docs/docs/api-reference/rest-api.mdx
+++ b/src/content/docs/docs/api-reference/rest-api.mdx
@@ -3,509 +3,33 @@ title: REST API Reference
 description: Complete REST API endpoint documentation
 ---
 
-Complete reference for all DuraGraph REST API endpoints.
+import { LinkCard } from '@astrojs/starlight/components';
 
-## Base URL
+For complete endpoint documentation with schemas and try-it-out functionality, see the interactive API reference.
 
-```
-/api/v1
-```
+<LinkCard
+  title="Interactive API Reference"
+  description="Explore all endpoints, view schemas, and test API calls directly in your browser"
+  href="/api/reference"
+/>
 
-## Assistants
+## Code Examples
 
-### Create Assistant
-
-```http
-POST /api/v1/assistants
-```
-
-Create a new AI assistant.
-
-**Request Body:**
-
-```json
-{
-  "name": "Customer Support Agent",
-  "config": {
-    "model": "gpt-4o-mini",
-    "temperature": 0.7,
-    "system_prompt": "You are a helpful assistant."
-  },
-  "metadata": {
-    "team": "support",
-    "version": "1.0"
-  }
-}
-```
-
-**Response:** `201 Created`
-
-```json
-{
-  "assistant_id": "223e4567-e89b-12d3-a456-426614174000",
-  "name": "Customer Support Agent",
-  "config": {},
-  "metadata": {},
-  "created_at": "2025-01-03T12:00:00Z",
-  "updated_at": "2025-01-03T12:00:00Z"
-}
-```
-
-### Get Assistant
-
-```http
-GET /api/v1/assistants/:assistant_id
-```
-
-**Response:** `200 OK`
-
-```json
-{
-  "assistant_id": "223e4567-e89b-12d3-a456-426614174000",
-  "name": "Customer Support Agent",
-  "config": {},
-  "metadata": {},
-  "created_at": "2025-01-03T12:00:00Z",
-  "updated_at": "2025-01-03T12:00:00Z"
-}
-```
-
-### List Assistants
-
-```http
-GET /api/v1/assistants?limit=50&cursor=xyz
-```
-
-**Query Parameters:**
-
-- `limit` (int, optional) - Items per page (default: 50, max: 100)
-- `cursor` (string, optional) - Pagination cursor
-
-**Response:** `200 OK`
-
-```json
-{
-  "data": [
-    {
-      "assistant_id": "...",
-      "name": "..."
-    }
-  ],
-  "has_more": true,
-  "next_cursor": "eyJpZCI6NTB9"
-}
-```
-
-### Update Assistant
-
-```http
-PATCH /api/v1/assistants/:assistant_id
-```
-
-**Request Body:**
-
-```json
-{
-  "name": "Updated Name",
-  "config": {
-    "temperature": 0.8
-  }
-}
-```
-
-**Response:** `200 OK`
-
-### Delete Assistant
-
-```http
-DELETE /api/v1/assistants/:assistant_id
-```
-
-**Response:** `204 No Content`
-
-## Threads
-
-### Create Thread
-
-```http
-POST /api/v1/threads
-```
-
-**Request Body:**
-
-```json
-{
-  "metadata": {
-    "user_id": "user_123",
-    "session": "web"
-  }
-}
-```
-
-**Response:** `201 Created`
-
-```json
-{
-  "thread_id": "123e4567-e89b-12d3-a456-426614174000",
-  "metadata": {},
-  "created_at": "2025-01-03T12:00:00Z",
-  "updated_at": "2025-01-03T12:00:00Z"
-}
-```
-
-### Get Thread
-
-```http
-GET /api/v1/threads/:thread_id
-```
-
-**Response:** `200 OK`
-
-### List Threads
-
-```http
-GET /api/v1/threads?limit=50&cursor=xyz
-```
-
-**Response:** `200 OK`
-
-### Update Thread
-
-```http
-PATCH /api/v1/threads/:thread_id
-```
-
-**Request Body:**
-
-```json
-{
-  "metadata": {
-    "status": "active"
-  }
-}
-```
-
-**Response:** `200 OK`
-
-### Add Message
-
-```http
-POST /api/v1/threads/:thread_id/messages
-```
-
-**Request Body:**
-
-```json
-{
-  "role": "user",
-  "content": "Hello, assistant!"
-}
-```
-
-**Response:** `201 Created`
-
-## Runs
-
-### Create Run
-
-```http
-POST /api/v1/runs
-```
-
-**Request Body:**
-
-```json
-{
-  "thread_id": "123e4567-e89b-12d3-a456-426614174000",
-  "assistant_id": "223e4567-e89b-12d3-a456-426614174000",
-  "input": {
-    "message": "Process this request"
-  },
-  "config": {
-    "max_concurrency": 5
-  }
-}
-```
-
-**Response:** `201 Created`
-
-```json
-{
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "thread_id": "123e4567-e89b-12d3-a456-426614174000",
-  "assistant_id": "223e4567-e89b-12d3-a456-426614174000",
-  "status": "queued",
-  "input": {},
-  "output": null,
-  "error": null,
-  "created_at": "2025-01-03T12:00:00Z",
-  "updated_at": "2025-01-03T12:00:00Z"
-}
-```
-
-**Run Status Values:**
-
-- `queued` - Waiting to start
-- `in_progress` - Currently executing
-- `requires_action` - Waiting for human input or tool outputs
-- `completed` - Successfully finished
-- `failed` - Execution failed
-- `cancelled` - Cancelled by user
-
-### Get Run
-
-```http
-GET /api/v1/runs/:run_id
-```
-
-**Response:** `200 OK`
-
-```json
-{
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "thread_id": "123e4567-e89b-12d3-a456-426614174000",
-  "assistant_id": "223e4567-e89b-12d3-a456-426614174000",
-  "status": "completed",
-  "input": {},
-  "output": {
-    "result": "Task completed successfully"
-  },
-  "error": null,
-  "created_at": "2025-01-03T12:00:00Z",
-  "updated_at": "2025-01-03T12:00:30Z"
-}
-```
-
-### List Runs
-
-```http
-GET /api/v1/threads/:thread_id/runs?limit=50&cursor=xyz
-```
-
-**Response:** `200 OK`
-
-### Submit Tool Outputs
-
-```http
-POST /api/v1/runs/:run_id/submit_tool_outputs
-```
-
-When a run enters `requires_action` status with tool calls, submit results:
-
-**Request Body:**
-
-```json
-{
-  "tool_outputs": [
-    {
-      "tool_call_id": "call_abc123",
-      "output": {
-        "result": "Search completed",
-        "data": [...]
-      }
-    }
-  ]
-}
-```
-
-**Response:** `200 OK`
-
-## State Management
-
-### Get Thread State
-
-```http
-GET /api/v1/threads/:thread_id/state
-```
-
-**Response:** `200 OK`
-
-```json
-{
-  "values": {
-    "messages": [],
-    "context": {}
-  },
-  "checkpoint_id": "chk_abc123",
-  "created_at": "2025-01-03T12:00:00Z"
-}
-```
-
-### Update Thread State
-
-```http
-POST /api/v1/threads/:thread_id/state
-```
-
-**Request Body:**
-
-```json
-{
-  "values": {
-    "context": { "key": "value" }
-  },
-  "as_node": "node_name"
-}
-```
-
-**Response:** `200 OK`
-
-### Get Checkpoint History
-
-```http
-GET /api/v1/threads/:thread_id/history
-```
-
-**Response:** `200 OK`
-
-```json
-{
-  "checkpoints": [
-    {
-      "checkpoint_id": "chk_abc123",
-      "values": {},
-      "created_at": "2025-01-03T12:00:00Z"
-    }
-  ]
-}
-```
-
-## Worker Management
-
-### Register Worker
-
-```http
-POST /api/v1/workers/register
-```
-
-**Request Body:**
-
-```json
-{
-  "worker_id": "worker_001",
-  "capabilities": ["python", "llm"],
-  "metadata": {
-    "version": "1.0.0"
-  }
-}
-```
-
-**Response:** `201 Created`
-
-### Heartbeat
-
-```http
-POST /api/v1/workers/:worker_id/heartbeat
-```
-
-**Request Body:**
-
-```json
-{
-  "status": "active",
-  "metrics": {
-    "tasks_processed": 42
-  }
-}
-```
-
-**Response:** `200 OK`
-
-### Deregister Worker
-
-```http
-DELETE /api/v1/workers/:worker_id
-```
-
-**Response:** `204 No Content`
-
-## Streaming
-
-### Stream Events
-
-```http
-GET /api/v1/stream?run_id={run_id}
-```
-
-Server-Sent Events endpoint for real-time updates.
-
-See [SSE Streaming](/docs/api-reference/sse-streaming) for details.
-
-## Error Responses
-
-All errors follow this format:
-
-```json
-{
-  "error": "error_code",
-  "message": "Human-readable description",
-  "details": {
-    "field": "Additional context"
-  }
-}
-```
-
-**Common Errors:**
-
-| Status | Error Code            | Description             |
-| ------ | --------------------- | ----------------------- |
-| 400    | `invalid_request`     | Malformed request body  |
-| 400    | `validation_error`    | Field validation failed |
-| 401    | `unauthorized`        | Missing or invalid auth |
-| 404    | `resource_not_found`  | Resource doesn't exist  |
-| 409    | `resource_conflict`   | Resource already exists |
-| 429    | `rate_limit_exceeded` | Too many requests       |
-| 500    | `internal_error`      | Server error            |
-
-**Example:**
-
-```json
-{
-  "error": "validation_error",
-  "message": "Invalid input",
-  "details": {
-    "thread_id": "Must be a valid UUID"
-  }
-}
-```
-
-## Rate Limiting
-
-Rate limit headers included in all responses:
-
-```
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1609459260
-```
-
-When rate limit exceeded:
-
-```json
-{
-  "error": "rate_limit_exceeded",
-  "message": "Too many requests",
-  "retry_after": 60
-}
-```
-
-## Examples
-
-### Complete Workflow
+### Complete Workflow (bash)
 
 ```bash
 # 1. Create assistant
-ASSISTANT=$(curl -X POST http://localhost:8081/api/v1/assistants \
+ASSISTANT=$(curl -s -X POST http://localhost:8081/api/v1/assistants \
   -H "Content-Type: application/json" \
   -d '{"name": "My Assistant", "config": {}}' | jq -r .assistant_id)
 
 # 2. Create thread
-THREAD=$(curl -X POST http://localhost:8081/api/v1/threads \
+THREAD=$(curl -s -X POST http://localhost:8081/api/v1/threads \
   -H "Content-Type: application/json" \
   -d '{"metadata": {}}' | jq -r .thread_id)
 
 # 3. Create run
-RUN=$(curl -X POST http://localhost:8081/api/v1/runs \
+RUN=$(curl -s -X POST http://localhost:8081/api/v1/runs \
   -H "Content-Type: application/json" \
   -d "{
     \"thread_id\": \"$THREAD\",
@@ -517,10 +41,10 @@ RUN=$(curl -X POST http://localhost:8081/api/v1/runs \
 curl -N "http://localhost:8081/api/v1/stream?run_id=$RUN"
 
 # 5. Get final result
-curl "http://localhost:8081/api/v1/runs/$RUN"
+curl -s "http://localhost:8081/api/v1/runs/$RUN" | jq
 ```
 
-### With Python
+### Python
 
 ```python
 import requests
@@ -550,7 +74,7 @@ result = requests.get(f"{base_url}/runs/{run['run_id']}").json()
 print(result)
 ```
 
-### With Go
+### Go
 
 ```go
 package main
@@ -558,6 +82,7 @@ package main
 import (
     "bytes"
     "encoding/json"
+    "fmt"
     "net/http"
 )
 
@@ -569,28 +94,124 @@ type Assistant struct {
     Config      map[string]interface{} `json:"config"`
 }
 
-func createAssistant() (*Assistant, error) {
+type Thread struct {
+    ThreadID string                 `json:"thread_id"`
+    Metadata map[string]interface{} `json:"metadata"`
+}
+
+type Run struct {
+    RunID       string                 `json:"run_id"`
+    ThreadID    string                 `json:"thread_id"`
+    AssistantID string                 `json:"assistant_id"`
+    Status      string                 `json:"status"`
+    Input       map[string]interface{} `json:"input"`
+    Output      map[string]interface{} `json:"output"`
+}
+
+func main() {
+    // Create assistant
+    assistant := createAssistant()
+    fmt.Printf("Created assistant: %s\n", assistant.AssistantID)
+
+    // Create thread
+    thread := createThread()
+    fmt.Printf("Created thread: %s\n", thread.ThreadID)
+
+    // Create run
+    run := createRun(thread.ThreadID, assistant.AssistantID)
+    fmt.Printf("Created run: %s (status: %s)\n", run.RunID, run.Status)
+}
+
+func createAssistant() *Assistant {
     body := map[string]interface{}{
         "name":   "My Assistant",
         "config": map[string]interface{}{},
     }
-
     data, _ := json.Marshal(body)
-    resp, err := http.Post(baseURL+"/assistants", "application/json", bytes.NewBuffer(data))
-    if err != nil {
-        return nil, err
-    }
+    resp, _ := http.Post(baseURL+"/assistants", "application/json", bytes.NewBuffer(data))
     defer resp.Body.Close()
 
     var assistant Assistant
     json.NewDecoder(resp.Body).Decode(&assistant)
-    return &assistant, nil
+    return &assistant
+}
+
+func createThread() *Thread {
+    body := map[string]interface{}{"metadata": map[string]interface{}{}}
+    data, _ := json.Marshal(body)
+    resp, _ := http.Post(baseURL+"/threads", "application/json", bytes.NewBuffer(data))
+    defer resp.Body.Close()
+
+    var thread Thread
+    json.NewDecoder(resp.Body).Decode(&thread)
+    return &thread
+}
+
+func createRun(threadID, assistantID string) *Run {
+    body := map[string]interface{}{
+        "thread_id":    threadID,
+        "assistant_id": assistantID,
+        "input":        map[string]interface{}{"message": "Hello"},
+    }
+    data, _ := json.Marshal(body)
+    resp, _ := http.Post(baseURL+"/runs", "application/json", bytes.NewBuffer(data))
+    defer resp.Body.Close()
+
+    var run Run
+    json.NewDecoder(resp.Body).Decode(&run)
+    return &run
+}
+```
+
+## Error Handling
+
+All errors follow a consistent format:
+
+```json
+{
+  "error": "error_code",
+  "message": "Human-readable description",
+  "details": {
+    "field": "Additional context"
+  }
+}
+```
+
+**Common Error Codes:**
+
+| Status | Error Code            | Description             |
+| ------ | --------------------- | ----------------------- |
+| 400    | `invalid_request`     | Malformed request body  |
+| 400    | `validation_error`    | Field validation failed |
+| 401    | `unauthorized`        | Missing or invalid auth |
+| 404    | `resource_not_found`  | Resource doesn't exist  |
+| 409    | `resource_conflict`   | Resource already exists |
+| 429    | `rate_limit_exceeded` | Too many requests       |
+| 500    | `internal_error`      | Server error            |
+
+## Rate Limiting
+
+Rate limit headers included in all responses:
+
+```
+X-RateLimit-Limit: 100
+X-RateLimit-Remaining: 95
+X-RateLimit-Reset: 1609459260
+```
+
+When rate limit exceeded:
+
+```json
+{
+  "error": "rate_limit_exceeded",
+  "message": "Too many requests",
+  "retry_after": 60
 }
 ```
 
 ## Next Steps
 
+- [Interactive API Reference](/api/reference) - Try endpoints directly
 - [SSE Streaming](/docs/api-reference/sse-streaming) - Real-time events
-- [Webhooks](/docs/api-reference/webhooks) - Event notifications
 - [Python SDK](/docs/sdk/python) - Python client
 - [Go SDK](/docs/sdk/go) - Go client

--- a/src/content/docs/docs/api-reference/sse-streaming.mdx
+++ b/src/content/docs/docs/api-reference/sse-streaming.mdx
@@ -3,7 +3,15 @@ title: Server-Sent Events (SSE) Streaming
 description: Real-time event streaming documentation
 ---
 
+import { LinkCard } from '@astrojs/starlight/components';
+
 DuraGraph provides real-time updates via Server-Sent Events (SSE) for monitoring workflow execution, LLM token streaming, and system events.
+
+<LinkCard
+  title="Interactive API Reference"
+  description="Try streaming endpoints directly in your browser"
+  href="/api/reference"
+/>
 
 ## Overview
 
@@ -14,48 +22,71 @@ SSE allows clients to receive push notifications from the server over a single H
 - Live workflow progress monitoring
 - Event-driven UIs
 
-## Endpoint
+## Event Types
 
-```http
-GET /api/v1/stream?run_id={run_id}
+### Run Events
+
+| Event                 | Description                             |
+| --------------------- | --------------------------------------- |
+| `run.started`         | Run execution began                     |
+| `run.completed`       | Run finished successfully               |
+| `run.failed`          | Run failed with error                   |
+| `run.requires_action` | Waiting for human input or tool outputs |
+
+### Node Events
+
+| Event            | Description             |
+| ---------------- | ----------------------- |
+| `node.started`   | Node began execution    |
+| `node.completed` | Node finished execution |
+
+### LLM Events
+
+| Event            | Description                             |
+| ---------------- | --------------------------------------- |
+| `llm.token`      | Single token generated (streaming mode) |
+| `llm.completion` | LLM completed generation                |
+
+### Tool Events
+
+| Event         | Description              |
+| ------------- | ------------------------ |
+| `tool.call`   | Tool was called          |
+| `tool.result` | Tool execution completed |
+
+### System Events
+
+| Event              | Description                    |
+| ------------------ | ------------------------------ |
+| `checkpoint.saved` | Workflow state checkpointed    |
+| `heartbeat`        | Periodic keepalive (every 30s) |
+| `error`            | Non-fatal error occurred       |
+
+## Event Flow Example
+
+Typical event sequence for a successful run:
+
+```
+data: {"type":"run.started","run_id":"..."}
+data: {"type":"node.started","node_id":"input"}
+data: {"type":"node.completed","node_id":"input"}
+data: {"type":"checkpoint.saved","checkpoint_id":"chk_1"}
+data: {"type":"node.started","node_id":"llm"}
+data: {"type":"llm.token","token":"Hello"}
+data: {"type":"llm.token","token":" there"}
+data: {"type":"llm.token","token":"!"}
+data: {"type":"llm.completion","content":"Hello there!"}
+data: {"type":"node.completed","node_id":"llm"}
+data: {"type":"run.completed","output":{"result":"..."}}
 ```
 
-**Query Parameters:**
+## Client Examples
 
-- `run_id` (required) - The run ID to stream events for
-
-## Connection
-
-### cURL
-
-```bash
-curl -N http://localhost:8081/api/v1/stream?run_id={run_id}
-```
-
-The `-N` flag disables buffering for immediate event delivery.
-
-### Python
-
-```python
-import requests
-
-run_id = "323e4567-e89b-12d3-a456-426614174000"
-url = f"http://localhost:8081/api/v1/stream?run_id={run_id}"
-
-with requests.get(url, stream=True) as response:
-    for line in response.iter_lines():
-        if line:
-            decoded = line.decode('utf-8')
-            if decoded.startswith('data: '):
-                data = decoded[6:]  # Remove 'data: ' prefix
-                print(data)
-```
-
-### JavaScript
+### JavaScript (EventSource)
 
 ```javascript
 const runId = '323e4567-e89b-12d3-a456-426614174000';
-const eventSource = new EventSource(`http://localhost:8081/api/v1/stream?run_id=${runId}`);
+const eventSource = new EventSource(`/api/v1/stream?run_id=${runId}`);
 
 eventSource.onmessage = (event) => {
   const data = JSON.parse(event.data);
@@ -63,8 +94,7 @@ eventSource.onmessage = (event) => {
 };
 
 eventSource.addEventListener('run.completed', (event) => {
-  const data = JSON.parse(event.data);
-  console.log('Run completed:', data);
+  console.log('Run completed:', JSON.parse(event.data));
   eventSource.close();
 });
 
@@ -74,18 +104,30 @@ eventSource.onerror = (error) => {
 };
 ```
 
+### Python
+
+```python
+import requests
+import json
+
+run_id = "323e4567-e89b-12d3-a456-426614174000"
+url = f"http://localhost:8081/api/v1/stream?run_id={run_id}"
+
+with requests.get(url, stream=True) as response:
+    for line in response.iter_lines():
+        if line:
+            decoded = line.decode('utf-8')
+            if decoded.startswith('data: '):
+                data = json.loads(decoded[6:])
+                print(f"Event: {data['type']}")
+
+                if data['type'] == 'run.completed':
+                    break
+```
+
 ### Go
 
 ```go
-package main
-
-import (
-    "bufio"
-    "fmt"
-    "net/http"
-    "strings"
-)
-
 func streamEvents(runID string) error {
     url := fmt.Sprintf("http://localhost:8081/api/v1/stream?run_id=%s", runID)
 
@@ -103,265 +145,13 @@ func streamEvents(runID string) error {
             fmt.Println("Event:", data)
         }
     }
-
     return scanner.Err()
 }
 ```
 
-## Event Types
-
-### Run Events
-
-#### `run.started`
-
-Emitted when run execution begins.
-
-```json
-{
-  "type": "run.started",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "timestamp": "2025-01-03T12:00:00Z"
-}
-```
-
-#### `run.completed`
-
-Emitted when run finishes successfully.
-
-```json
-{
-  "type": "run.completed",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "output": {
-    "result": "Task completed"
-  },
-  "timestamp": "2025-01-03T12:00:30Z"
-}
-```
-
-#### `run.failed`
-
-Emitted when run fails with an error.
-
-```json
-{
-  "type": "run.failed",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "error": {
-    "code": "execution_error",
-    "message": "Node execution failed",
-    "details": {}
-  },
-  "timestamp": "2025-01-03T12:00:15Z"
-}
-```
-
-#### `run.requires_action`
-
-Emitted when run needs human input or tool outputs.
-
-```json
-{
-  "type": "run.requires_action",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "required_action": {
-    "type": "submit_tool_outputs",
-    "submit_tool_outputs": {
-      "tool_calls": [
-        {
-          "id": "call_abc123",
-          "type": "function",
-          "function": {
-            "name": "web_search",
-            "arguments": "{\"query\": \"AI agents\"}"
-          }
-        }
-      ]
-    }
-  },
-  "timestamp": "2025-01-03T12:00:10Z"
-}
-```
-
-### Node Events
-
-#### `node.started`
-
-Emitted when a node begins execution.
-
-```json
-{
-  "type": "node.started",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "node_id": "process_input",
-  "node_type": "llm",
-  "timestamp": "2025-01-03T12:00:05Z"
-}
-```
-
-#### `node.completed`
-
-Emitted when a node finishes execution.
-
-```json
-{
-  "type": "node.completed",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "node_id": "process_input",
-  "output": {
-    "result": "Processed"
-  },
-  "timestamp": "2025-01-03T12:00:08Z"
-}
-```
-
-### LLM Events
-
-#### `llm.token`
-
-Emitted for each token generated by LLM (streaming mode).
-
-```json
-{
-  "type": "llm.token",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "node_id": "generate_response",
-  "token": "Hello",
-  "timestamp": "2025-01-03T12:00:06.123Z"
-}
-```
-
-#### `llm.completion`
-
-Emitted when LLM completes generation.
-
-```json
-{
-  "type": "llm.completion",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "node_id": "generate_response",
-  "content": "Hello! How can I help you today?",
-  "model": "gpt-4o-mini",
-  "usage": {
-    "prompt_tokens": 10,
-    "completion_tokens": 8,
-    "total_tokens": 18
-  },
-  "timestamp": "2025-01-03T12:00:08Z"
-}
-```
-
-### Tool Events
-
-#### `tool.call`
-
-Emitted when a tool is called.
-
-```json
-{
-  "type": "tool.call",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "tool_call_id": "call_abc123",
-  "tool_name": "web_search",
-  "arguments": {
-    "query": "AI agents"
-  },
-  "timestamp": "2025-01-03T12:00:10Z"
-}
-```
-
-#### `tool.result`
-
-Emitted when tool execution completes.
-
-```json
-{
-  "type": "tool.result",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "tool_call_id": "call_abc123",
-  "result": {
-    "results": [...]
-  },
-  "timestamp": "2025-01-03T12:00:12Z"
-}
-```
-
-### Checkpoint Events
-
-#### `checkpoint.saved`
-
-Emitted when workflow state is checkpointed.
-
-```json
-{
-  "type": "checkpoint.saved",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "checkpoint_id": "chk_abc123",
-  "timestamp": "2025-01-03T12:00:10Z"
-}
-```
-
-### System Events
-
-#### `heartbeat`
-
-Periodic keepalive event (every 30 seconds).
-
-```json
-{
-  "type": "heartbeat",
-  "timestamp": "2025-01-03T12:00:30Z"
-}
-```
-
-#### `error`
-
-Emitted for non-fatal errors.
-
-```json
-{
-  "type": "error",
-  "run_id": "323e4567-e89b-12d3-a456-426614174000",
-  "error": {
-    "message": "Warning: Rate limit approaching"
-  },
-  "timestamp": "2025-01-03T12:00:15Z"
-}
-```
-
-## Event Flow Example
-
-Typical event sequence for a successful run:
-
-```
-data: {"type":"run.started","run_id":"..."}
-
-data: {"type":"node.started","node_id":"input"}
-
-data: {"type":"node.completed","node_id":"input"}
-
-data: {"type":"checkpoint.saved","checkpoint_id":"chk_1"}
-
-data: {"type":"node.started","node_id":"llm"}
-
-data: {"type":"llm.token","token":"Hello"}
-data: {"type":"llm.token","token":" there"}
-data: {"type":"llm.token","token":"!"}
-
-data: {"type":"llm.completion","content":"Hello there!"}
-
-data: {"type":"node.completed","node_id":"llm"}
-
-data: {"type":"checkpoint.saved","checkpoint_id":"chk_2"}
-
-data: {"type":"run.completed","output":{"result":"..."}}
-```
-
 ## Best Practices
 
-### Reconnection
-
-Implement automatic reconnection with exponential backoff:
+### Reconnection with Exponential Backoff
 
 ```javascript
 class SSEClient {
@@ -376,7 +166,6 @@ class SSEClient {
 
     this.eventSource.onerror = () => {
       this.eventSource.close();
-
       setTimeout(() => {
         this.retryDelay = Math.min(this.retryDelay * 2, this.maxRetryDelay);
         this.connect();
@@ -384,115 +173,13 @@ class SSEClient {
     };
 
     this.eventSource.onopen = () => {
-      this.retryDelay = 1000; // Reset on successful connection
+      this.retryDelay = 1000; // Reset on success
     };
   }
 }
 ```
 
-### Event Filtering
-
-Filter events client-side for specific types:
-
-```python
-def stream_llm_tokens(run_id):
-    url = f"http://localhost:8081/api/v1/stream?run_id={run_id}"
-
-    with requests.get(url, stream=True) as response:
-        for line in response.iter_lines():
-            if line:
-                decoded = line.decode('utf-8')
-                if decoded.startswith('data: '):
-                    data = json.loads(decoded[6:])
-
-                    # Only process LLM tokens
-                    if data.get('type') == 'llm.token':
-                        print(data['token'], end='', flush=True)
-```
-
-### Timeout Handling
-
-Set appropriate timeouts:
-
-```python
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
-
-session = requests.Session()
-retry = Retry(total=3, backoff_factor=1)
-adapter = HTTPAdapter(max_retries=retry)
-session.mount('http://', adapter)
-
-response = session.get(
-    url,
-    stream=True,
-    timeout=(5, None)  # 5s connect timeout, no read timeout
-)
-```
-
-### Resource Cleanup
-
-Always close connections when done:
-
-```javascript
-const eventSource = new EventSource(url);
-
-// Close on completion
-eventSource.addEventListener('run.completed', () => {
-  eventSource.close();
-});
-
-// Close on page unload
-window.addEventListener('beforeunload', () => {
-  eventSource.close();
-});
-```
-
-## Error Handling
-
-### Connection Errors
-
-```javascript
-eventSource.onerror = (error) => {
-  if (eventSource.readyState === EventSource.CLOSED) {
-    console.error('Connection closed');
-    // Implement reconnection logic
-  } else {
-    console.error('SSE error:', error);
-  }
-};
-```
-
-### Invalid Run ID
-
-```
-HTTP/1.1 404 Not Found
-Content-Type: application/json
-
-{
-  "error": "resource_not_found",
-  "message": "Run not found"
-}
-```
-
-### Authentication Error
-
-```
-HTTP/1.1 401 Unauthorized
-Content-Type: application/json
-
-{
-  "error": "unauthorized",
-  "message": "Missing or invalid API key"
-}
-```
-
-## Performance Considerations
-
-### Client-Side Buffering
-
-For token streaming, buffer tokens for smoother rendering:
+### Token Buffering for Smooth UI
 
 ```javascript
 let buffer = '';
@@ -510,79 +197,41 @@ eventSource.addEventListener('llm.token', (event) => {
 });
 ```
 
-### Memory Management
+### Resource Cleanup
 
-Limit event history to prevent memory leaks:
+```javascript
+// Close on completion
+eventSource.addEventListener('run.completed', () => {
+  eventSource.close();
+});
+
+// Close on page unload
+window.addEventListener('beforeunload', () => {
+  eventSource.close();
+});
+```
+
+### Memory Management
 
 ```javascript
 const MAX_EVENTS = 1000;
 const events = [];
 
 eventSource.onmessage = (event) => {
-  const data = JSON.parse(event.data);
-  events.push(data);
-
+  events.push(JSON.parse(event.data));
   if (events.length > MAX_EVENTS) {
-    events.shift(); // Remove oldest event
+    events.shift(); // Remove oldest
   }
 };
 ```
 
-## Testing
-
-### Manual Testing
-
-```bash
-# Test basic connection
-curl -N http://localhost:8081/api/v1/stream?run_id={run_id}
-
-# Test with timeout
-timeout 30s curl -N http://localhost:8081/api/v1/stream?run_id={run_id}
-
-# Save events to file
-curl -N http://localhost:8081/api/v1/stream?run_id={run_id} > events.log
-```
-
-### Integration Testing
-
-```python
-import pytest
-import requests
-
-def test_sse_stream():
-    # Create run
-    run = create_test_run()
-
-    # Stream events
-    url = f"http://localhost:8081/api/v1/stream?run_id={run['run_id']}"
-    events = []
-
-    with requests.get(url, stream=True, timeout=30) as response:
-        for line in response.iter_lines():
-            if line:
-                decoded = line.decode('utf-8')
-                if decoded.startswith('data: '):
-                    data = json.loads(decoded[6:])
-                    events.append(data)
-
-                    # Stop after completion
-                    if data.get('type') == 'run.completed':
-                        break
-
-    # Verify event sequence
-    assert events[0]['type'] == 'run.started'
-    assert events[-1]['type'] == 'run.completed'
-```
-
-## Examples
-
-### Real-time Chat UI
+## Real-time Chat UI Example
 
 ```javascript
 class ChatStream {
   constructor(runId) {
     this.runId = runId;
-    this.messageContainer = document.getElementById('messages');
+    this.container = document.getElementById('messages');
     this.currentMessage = '';
   }
 
@@ -593,56 +242,19 @@ class ChatStream {
     this.eventSource.addEventListener('llm.token', (event) => {
       const data = JSON.parse(event.data);
       this.currentMessage += data.token;
-      this.updateMessageDisplay();
+      this.container.textContent = this.currentMessage;
     });
 
-    this.eventSource.addEventListener('llm.completion', (event) => {
-      this.finalizeMessage();
-    });
-
-    this.eventSource.addEventListener('run.completed', (event) => {
+    this.eventSource.addEventListener('run.completed', () => {
+      this.container.classList.add('complete');
       this.eventSource.close();
     });
-  }
-
-  updateMessageDisplay() {
-    // Update UI with streaming text
-    this.messageContainer.textContent = this.currentMessage;
-  }
-
-  finalizeMessage() {
-    // Finalize message display
-    this.messageContainer.classList.add('complete');
   }
 }
 ```
 
-### Progress Tracking
-
-```python
-def track_progress(run_id):
-    url = f"http://localhost:8081/api/v1/stream?run_id={run_id}"
-    nodes_completed = set()
-
-    with requests.get(url, stream=True) as response:
-        for line in response.iter_lines():
-            if line:
-                decoded = line.decode('utf-8')
-                if decoded.startswith('data: '):
-                    data = json.loads(decoded[6:])
-
-                    if data.get('type') == 'node.completed':
-                        node_id = data['node_id']
-                        nodes_completed.add(node_id)
-                        print(f"Progress: {len(nodes_completed)} nodes completed")
-
-                    elif data.get('type') == 'run.completed':
-                        print("Run completed!")
-                        break
-```
-
 ## Next Steps
 
-- [REST API Reference](/docs/api-reference/rest-api) - Complete endpoint docs
+- [Interactive API Reference](/api/reference) - Try streaming endpoints
+- [REST API Reference](/docs/api-reference/rest-api) - Code examples
 - [Webhooks](/docs/api-reference/webhooks) - Alternative event delivery
-- [Examples](/docs/api-reference/examples) - More code samples

--- a/src/pages/api/reference.astro
+++ b/src/pages/api/reference.astro
@@ -6,20 +6,74 @@ import { ScalarComponent } from '@scalar/astro';
   configuration={{
     url: '/openapi.yaml',
     pageTitle: 'DuraGraph API Reference',
-    theme: 'purple',
+    theme: 'default',
     hideModels: false,
     hideDownloadButton: false,
-    darkMode: true,
+    withDefaultFonts: false,
     metaData: {
       title: 'DuraGraph API Reference',
       description:
         'Interactive API documentation for DuraGraph - LangGraph Cloud-compatible AI workflow orchestration',
     },
     customCss: `
+      @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+      /* Base styles */
       .scalar-app {
-        --scalar-color-accent: #f97316;
-        --scalar-color-1: #ea580c;
-        --scalar-color-2: #c2410c;
+        --scalar-font: 'Space Grotesk', system-ui, sans-serif;
+        --scalar-font-code: 'JetBrains Mono', ui-monospace, monospace;
+        --scalar-radius: 0;
+        --scalar-radius-lg: 0;
+        --scalar-radius-xl: 0;
+      }
+
+      /* Light mode */
+      .light-mode {
+        --scalar-background-1: #ffffff;
+        --scalar-background-2: #f4f5f5;
+        --scalar-background-3: #e9eaea;
+        --scalar-color-1: #1e2330;
+        --scalar-color-2: #495466;
+        --scalar-color-3: #68778d;
+        --scalar-color-accent: #ea580c;
+        --scalar-border-color: #e0e2e3;
+      }
+
+      .light-mode .sidebar {
+        --scalar-sidebar-background-1: #f4f5f5;
+        --scalar-sidebar-color-1: #1e2330;
+        --scalar-sidebar-color-2: #495466;
+        --scalar-sidebar-color-active: #ea580c;
+        --scalar-sidebar-border-color: #e0e2e3;
+        --scalar-sidebar-item-active-background: rgba(234, 88, 12, 0.1);
+      }
+
+      /* Dark mode - matching Starlight exactly */
+      .dark-mode {
+        --scalar-background-1: #181a1b;
+        --scalar-background-2: #1f2123;
+        --scalar-background-3: #272a2c;
+        --scalar-color-1: #e0e2e4;
+        --scalar-color-2: #a8adb3;
+        --scalar-color-3: #6b7280;
+        --scalar-color-accent: #fb923c;
+        --scalar-border-color: #2e3133;
+      }
+
+      .dark-mode .sidebar {
+        --scalar-sidebar-background-1: #181a1b;
+        --scalar-sidebar-color-1: #e0e2e4;
+        --scalar-sidebar-color-2: #a8adb3;
+        --scalar-sidebar-color-active: #fb923c;
+        --scalar-sidebar-border-color: #2e3133;
+        --scalar-sidebar-item-active-background: rgba(251, 146, 60, 0.15);
+      }
+
+      /* Force sharp corners */
+      .scalar-app *,
+      .scalar-app button,
+      .scalar-app input {
+        border-radius: 0 !important;
       }
     `,
   }}

--- a/src/pages/api/reference.astro
+++ b/src/pages/api/reference.astro
@@ -1,0 +1,26 @@
+---
+import { ScalarComponent } from '@scalar/astro';
+---
+
+<ScalarComponent
+  configuration={{
+    url: '/openapi.yaml',
+    pageTitle: 'DuraGraph API Reference',
+    theme: 'purple',
+    hideModels: false,
+    hideDownloadButton: false,
+    darkMode: true,
+    metaData: {
+      title: 'DuraGraph API Reference',
+      description:
+        'Interactive API documentation for DuraGraph - LangGraph Cloud-compatible AI workflow orchestration',
+    },
+    customCss: `
+      .scalar-app {
+        --scalar-color-accent: #f97316;
+        --scalar-color-1: #ea580c;
+        --scalar-color-2: #c2410c;
+      }
+    `,
+  }}
+/>


### PR DESCRIPTION
## Summary

Replaces static API documentation with Scalar for a modern, interactive API reference experience.

## Changes

- Install `@scalar/astro` package for modern API documentation
- Add interactive API reference page at `/api/reference`
- Copy OpenAPI spec to public folder for Scalar to consume
- Update API overview to link to interactive reference
- Custom theme with DuraGraph coral accent colors

## Why Scalar over Swagger?

| Feature | Scalar | Swagger UI |
|---------|--------|------------|
| Modern UI | ✅ | ❌ Dated |
| Built-in API client | ✅ | ❌ |
| Try-it-out | ✅ Full | ⚠️ Basic |
| Free customization | ✅ | ⚠️ Limited |

## Features

- **Interactive API playground** - Test endpoints directly in browser
- **Modern UI** - Clean, professional design matching DuraGraph branding
- **Auto-generated from OpenAPI** - Stays in sync with API spec
- **Code examples** - Auto-generates in multiple languages
- **Dark mode** - Matches docs theme

## Test Plan

- [x] Local build passes
- [x] Dev server renders Scalar page
- [x] OpenAPI spec loads correctly
- [x] Pre-push hooks pass (build, validation, links)

## Preview

Visit `/api/reference` after deployment to see the interactive API documentation.

## URLs

- **Interactive API Reference**: `/api/reference`
- **API Overview** (updated with link): `/docs/api-reference/overview`